### PR TITLE
Fix zellij mappings for up/down

### DIFF
--- a/lua/Navigator/mux/zellij.lua
+++ b/lua/Navigator/mux/zellij.lua
@@ -34,8 +34,8 @@ function Zellij:new()
         direction = {
             p = 'focus-previous-pane',
             h = 'move-focus-or-tab left',
-            j = 'move-focus-or-tab down',
-            k = 'move-focus-or-tab up',
+            j = 'move-focus down',
+            k = 'move-focus up',
             l = 'move-focus-or-tab right',
         },
     }


### PR DESCRIPTION
Hey there,

I'm using your fork, on latest zellij the "move-focus-or-tab" don't work with up/down (they behave weirdly sometimes jumping directly to other tab?)
So replacing these two with more basic `move-focus`